### PR TITLE
Added missing imports property in module generation for registerAsync

### DIFF
--- a/src/schematics/dynmod/files/ts/__name__.module.ts
+++ b/src/schematics/dynmod/files/ts/__name__.module.ts
@@ -37,6 +37,7 @@ export class <%= classify(name) %>Module {
   ): DynamicModule {
     return {
       module: <%= classify(name) %>Module,
+      imports: options.imports || [],
       providers: [
         ...this.createProviders(options),
       ],

--- a/src/schematics/dynpkg/files/ts/src/__name__.module.ts
+++ b/src/schematics/dynpkg/files/ts/src/__name__.module.ts
@@ -37,6 +37,7 @@ export class <%= classify(name) %>Module {
   ): DynamicModule {
     return {
       module: <%= classify(name) %>Module,
+      imports: options.imports || [],
       providers: [
         ...this.createProviders(options),
       ],


### PR DESCRIPTION
Hello, 

At first thank you for your super package :)

I just made a small fix about the module generation, the "imports" property in the registerAsync methods was missing.

And so we couldn't load our module with a ConfigModule :

```
MyModule.registerAsync({
  imports: [ConfigModule],
  useFactory: async (configService: ConfigService) => ({
    url: configService.getString('URL')
  }),
  inject: [ConfigService],
}),
```

Thanks for reviewing.