### PR TITLE
fix: #21 update schema id to $id

### DIFF
--- a/src/schematics/dynmod/schema.json
+++ b/src/schematics/dynmod/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "DynamicModuleschema",
+  "$id": "DynamicModuleschema",
   "title": "Nest Dynamic Module Options Schema",
   "type": "object",
   "properties": {

--- a/src/schematics/dynpkg/schema.json
+++ b/src/schematics/dynpkg/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "id": "DynamicModuleschema",
+  "$id": "DynamicModuleschema",
   "title": "Nest Dynamic Module Options Schema",
   "type": "object",
   "properties": {


### PR DESCRIPTION
Resolves the following error:
```
nest g -c @nestjsplus/dyn-schematics dynpkg my-module
Error: NOT SUPPORTED: keyword "id", use "$id" for schema ID

Failed to execute command: node @nestjsplus/dyn-schematics:dynpkg --name=my-module --no-dry-run --collection="@nestjsplus/dyn-schematics" --no-skip-import --language="ts" --source-root="src" --spec --no-flat --spec-file-suffix="spec"
```

Closes #21